### PR TITLE
Modernize Dockerfile: Ubuntu 14.04 → 22.04, drop pyenv and ffmpeg compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN cpanm CPAN::Meta \
   Digest::SHA \
   Module::Build \
   ExtUtils::MakeMaker \
-  LWP::Simple
+  LWP::Simple \
+  CGI
 
 # Install separately as before — SSL deps benefit from a clean layer
 RUN cpanm Net::SSLeay \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,131 +1,79 @@
 # Set the base image to Ubuntu
-FROM ubuntu:14.04
+FROM ubuntu:22.04
 
-# File Author / Maintainer
-MAINTAINER Jonathan Epstein <jonathanepstein9@gmail.com>
+LABEL maintainer="Jonathan Epstein <jonathanepstein9@gmail.com>"
 
-# This project is constrained to use the Perl 'GD' module.   It also
-# needs a simple Text-to-Speech command-line tool, for which Google's
-# "gtts" is a good option.   Unfortanately at present these two requirements
-# tie us to older versions of Ubuntu, Perl and Python than one would prefer.
+# Suppress interactive prompts during apt installs
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Update the repository sources list
-RUN apt-get update
+# Install system dependencies in one layer.
+# ffmpeg is available in Ubuntu 22.04 repos with libmp3lame support built in,
+# so we no longer need to compile it from source.
+RUN apt-get update && apt-get install --yes \
+  apt-utils \
+  build-essential \
+  gcc-multilib \
+  perl \
+  cpanminus \
+  expat \
+  libexpat1-dev \
+  libreadline-dev \
+  libbz2-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  zlib1g-dev \
+  libgd-dev \
+  libmp3lame-dev \
+  libarchive-zip-perl \
+  tesseract-ocr \
+  libtesseract-dev \
+  tesseract-ocr-heb \
+  mp3wrap \
+  ffmpeg \
+  python3 \
+  python3-pip \
+  curl \
+  git \
+  ca-certificates
 
-# Install compiler and perl stuff
-RUN apt-get install --yes \
- build-essential \
- gcc-multilib \
- apt-utils \
- perl \
- expat \
- libexpat-dev \
- tesseract-ocr \
- libtesseract-dev \
- tesseract-ocr-heb \
- mp3wrap
-
-# Install perl modules
-RUN apt-get install -y cpanminus
-
+# Install Perl modules
 RUN cpanm CPAN::Meta \
- readline \
- Term::ReadKey \
- YAML \
- Digest::SHA \
- Module::Build \
- ExtUtils::MakeMaker \
- LWP::Simple
+  readline \
+  Term::ReadKey \
+  YAML \
+  Digest::SHA \
+  Module::Build \
+  ExtUtils::MakeMaker \
+  LWP::Simple
 
-
-RUN apt-get install --yes \
- libssl-dev \
- zlib1g-dev
-
-# for some reason we can't install this at the same time as the other modules
+# Install separately as before — SSL deps benefit from a clean layer
 RUN cpanm Net::SSLeay \
- IO::Socket::SSL \
- LWP::Protocol::https
+  IO::Socket::SSL \
+  LWP::Protocol::https
 
-# Let's try this one separately too
 RUN cpanm utf8::all
 
-RUN apt-get install --yes \
- libarchive-zip-perl
-
-# Install GD
-RUN apt-get remove --yes libgd-gd2-perl
-
-RUN apt-get install --yes \
- libgd2-noxpm-dev
-
 RUN cpanm GD \
- GD::Text \
- JSON::Parse
+  GD::Text \
+  JSON::Parse
 
-RUN apt-get install --yes \
- libmp3lame-dev
-
-RUN mkdir ffmpeg-source && \
-  cd ffmpeg-source && \
-  curl -k -o ffmpeg.tar.gz https://ffmpeg.org/releases/ffmpeg-6.0.tar.gz && \
-  tar xzf ffmpeg.tar.gz && \
-  cd ffmpeg-6.0/ && \
-  ./configure --disable-x86asm --enable-libmp3lame && \
-  make && \
-  cp ffmpeg /usr/local/bin
-
-
-# Copy-hacked from tomersha/docker-ubuntu-14.04-python-3.6.2
-# PyEnv
-ENV PYENV_ROOT /root/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-# Configure Python not to try to write .pyc files on the import of source modules
-ENV PYTHONDONTWRITEBYTECODE true
-ENV PYTHON_VERSION 3.6.2
-
-RUN sudo apt-get update -q \
-    && sudo apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        libbz2-dev \
-        libreadline-dev \
-        libsqlite3-dev \
-        libssl-dev \
-        zlib1g-dev
-
-# Install pyenv and default python version
-RUN git clone https://github.com/yyuu/pyenv.git /root/.pyenv \
-    && cd /root/.pyenv \
-    && git checkout `git describe --abbrev=0 --tags` \
-    && sudo echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc \
-    && sudo echo 'eval "$(pyenv init -)"'               >> ~/.bashrc
-
-RUN pyenv install $PYTHON_VERSION
-RUN pyenv local $PYTHON_VERSION
-
-# Text-to-speech for ScrollScraper's buildmp3.cgi
-RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org gTTS
-
-
-# Google Drive downloader for some large files which don't fit in free Github
-RUN pip install gdown
+# Text-to-speech and Google Drive downloader
+RUN pip3 install gTTS gdown
 
 WORKDIR /var/opt
-RUN mkdir scrollscraper
-RUN mkdir scrollscraper/data
-RUN mkdir scrollscraper/intermediate_outputs
-RUN mkdir scrollscraper/final_outputs
-RUN mkdir scrollscraper/fonts
-RUN mkdir scrollscraper/ScrollScraperalphaPNGs
-RUN mkdir scrollscraper/otherComputedPNGs
-RUN mkdir scrollscraper/webmedia
-RUN mkdir scrollscraper/cgi-bin
-RUN mkdir scrollscraper/scrollscraperWorkingDir
-RUN chmod 777 scrollscraper/scrollscraperWorkingDir
-RUN chmod 755 /root
+RUN mkdir -p \
+  scrollscraper/data \
+  scrollscraper/intermediate_outputs \
+  scrollscraper/final_outputs \
+  scrollscraper/fonts \
+  scrollscraper/ScrollScraperalphaPNGs \
+  scrollscraper/otherComputedPNGs \
+  scrollscraper/webmedia \
+  scrollscraper/cgi-bin \
+  scrollscraper/scrollscraperWorkingDir
+
+RUN chmod 777 scrollscraper/scrollscraperWorkingDir && chmod 755 /root
+
 ADD data/webmedia.tgz /var/opt/scrollscraper/webmedia
 COPY data/entire_torah.json /var/opt/scrollscraper/data
 COPY ScrollScraperalphaPNGs/* /var/opt/scrollscraper/ScrollScraperalphaPNGs
@@ -147,12 +95,16 @@ ADD *.txt /var/opt/scrollscraper
 ADD *.gif /var/opt/scrollscraper
 ADD *.mp3 /var/opt/scrollscraper
 ADD *.GIF /var/opt/scrollscraper
+
 RUN chmod 755 /var/opt/scrollscraper/cgi-bin/*.cgi
-RUN touch /var/opt/scrollscraper/intermediate_outputs/gif_names.txt
-RUN touch /var/opt/scrollscraper/intermediate_outputs/color_analysis.csv
-RUN touch /var/opt/scrollscraper/final_outputs/gif_info.csv
-RUN touch /var/opt/scrollscraper/intermediate_outputs/augmented_color_analysis_with_verses.csv
-RUN touch /var/opt/scrollscraper/final_outputs/map.csv
+
+RUN touch \
+  /var/opt/scrollscraper/intermediate_outputs/gif_names.txt \
+  /var/opt/scrollscraper/intermediate_outputs/color_analysis.csv \
+  /var/opt/scrollscraper/final_outputs/gif_info.csv \
+  /var/opt/scrollscraper/intermediate_outputs/augmented_color_analysis_with_verses.csv \
+  /var/opt/scrollscraper/final_outputs/map.csv
+
 ENV IS_DOCKER=1
 ENV PERL5LIB=/var/opt/scrollscraper/cgi-bin
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary

- Upgrades base image from `ubuntu:14.04` to `ubuntu:22.04`
- Drops the ~30-minute from-source ffmpeg 6.0 build — Ubuntu 22.04 ships ffmpeg with `libmp3lame` support in its apt repos
- Drops pyenv and the pinned Python 3.6.2 — replaced by `python3`/`python3-pip` system packages (Python 3.10+)
- Fixes package names for 22.04: `libexpat-dev` → `libexpat1-dev`, `libgd2-noxpm-dev` → `libgd-dev`, removes the now-unnecessary `libgd-gd2-perl` removal step
- Adds `DEBIAN_FRONTEND=noninteractive` to prevent apt prompts from hanging the build
- Consolidates the many separate `mkdir` and `RUN` steps for cleanliness

## Why this unblocks everything else

The old base image constraint was the reason the Docker image was never promoted to production. This removes that constraint and is a prerequisite for the Fargate migration (subsequent PRs).

## Test plan

- [ ] `docker build -t scrollscraper .` completes successfully
- [ ] `make test` passes inside the container
- [ ] `make test-mp3` passes (validates ffmpeg + gTTS still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)