### PR TITLE
Add docker-compose deployment and updated nginx config for EC2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,17 @@
 # Local Mac dev: leave unset to use ./local_ort_mp3s (populated via: make download-mp3s)
 MP3_DIR=
 
-# Absolute path to the persistent state directory (rate-limiting data).
+# Absolute path to the persistent state directory.
+# Holds rate-limiting lock + IP database, AND the generated MP3 cache.
 # EC2 production: create once with: mkdir -p /var/opt/scrollscraper-state/smil
 #   STATE_DIR=/var/opt/scrollscraper-state
 # Local Mac dev: leave unset to use ./state
 STATE_DIR=
+
+# Absolute path for buildmp3.cgi's shell-script working directory.
+# Scripts are generated here, executed synchronously, and accumulate over time
+# (useful for debugging). Mount on the host so they survive container restarts.
+# EC2 production:
+#   WORK_DIR=/var/opt/scrollscraper-workdir
+# Local Mac dev: leave unset to use ./scrollscraperWorkingDir
+WORK_DIR=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and set values for your environment.
+# .env is gitignored — never commit it.
+
+# Absolute path to the ORT MP3 directory on this host.
+# EC2 production:
+#   MP3_DIR=/srv/www/scrollscraper.adatshalom.net/public_html/ORT_MP3s.recoded
+# Local Mac dev: leave unset to use ./local_ort_mp3s (populated via: make download-mp3s)
+MP3_DIR=
+
+# Absolute path to the persistent state directory (rate-limiting data).
+# EC2 production: create once with: mkdir -p /var/opt/scrollscraper-state/smil
+#   STATE_DIR=/var/opt/scrollscraper-state
+# Local Mac dev: leave unset to use ./state
+STATE_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+local_ort_mp3s/
+download-mp3s

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 local_ort_mp3s/
+scrollscraperWorkingDir/
+state/
 download-mp3s

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,11 +25,15 @@ docker build -t scrollscraper .
 
 The first build takes 10–15 minutes. Subsequent rebuilds are faster due to layer caching.
 
-## 3. Create the state directory
+## 3. Create persistent directories on the host
 
 ```bash
+# Rate-limiting state + generated MP3 cache
 mkdir -p /var/opt/scrollscraper-state/smil
 touch /var/opt/scrollscraper-state/smil/daystampAndLock.txt
+
+# buildmp3.cgi shell-script working directory
+mkdir -p /var/opt/scrollscraper-workdir
 ```
 
 ## 4. Configure the environment
@@ -38,11 +42,12 @@ touch /var/opt/scrollscraper-state/smil/daystampAndLock.txt
 cp .env.example .env
 ```
 
-Edit `.env` and set both variables for production:
+Edit `.env` and set all three variables for production:
 
 ```
 MP3_DIR=/srv/www/scrollscraper.adatshalom.net/public_html/ORT_MP3s.recoded
 STATE_DIR=/var/opt/scrollscraper-state
+WORK_DIR=/var/opt/scrollscraper-workdir
 ```
 
 ## 5. Start the container

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,118 @@
+# EC2 Deployment Guide
+
+This document covers deploying ScrollScraper via docker-compose on the existing EC2,
+replacing the current fastcgi-wrapper setup. nginx remains on the host for TLS
+termination; the application runs inside a Docker container.
+
+## Prerequisites
+
+- Docker and docker-compose installed (docker-compose was installed at `/usr/local/bin/docker-compose`)
+- The Docker image built on the EC2 (see below)
+- The MP3 files already present on the host
+
+## 1. Clone / update the repo on the EC2
+
+```bash
+cd /newvolume/dockerWork122023/checkout/scrollscraper
+git pull
+```
+
+## 2. Build the Docker image
+
+```bash
+docker build -t scrollscraper .
+```
+
+The first build takes 10–15 minutes. Subsequent rebuilds are faster due to layer caching.
+
+## 3. Create the state directory
+
+```bash
+mkdir -p /var/opt/scrollscraper-state/smil
+touch /var/opt/scrollscraper-state/smil/daystampAndLock.txt
+```
+
+## 4. Configure the environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set both variables for production:
+
+```
+MP3_DIR=/srv/www/scrollscraper.adatshalom.net/public_html/ORT_MP3s.recoded
+STATE_DIR=/var/opt/scrollscraper-state
+```
+
+## 5. Start the container
+
+```bash
+docker-compose up -d
+```
+
+Verify it is running:
+
+```bash
+docker-compose ps
+curl -s http://127.0.0.1:8080/cgi-bin/scrollscraper.cgi \
+  "book=2&startc=15&startv=27&endc=15&endv=27" | head -5
+```
+
+## 6. Update the nginx config
+
+Back up the existing config, install the new one, test, and reload:
+
+```bash
+cp /etc/nginx/conf.d/scrollscraper.conf \
+   /etc/nginx/conf.d/scrollscraper.conf.pre-docker
+
+cp deploy/nginx-scrollscraper.conf /etc/nginx/conf.d/scrollscraper.conf
+
+nginx -t && service nginx reload
+```
+
+The site should now be live. Test in a browser:
+`https://scrollscraper.adatshalom.net/scrollscraper.cgi?book=2&startc=15&startv=27&endc=15&endv=27`
+
+## 7. Stop the old fastcgi-wrapper
+
+Once the Docker-based site is confirmed working:
+
+```bash
+kill $(pgrep -f fastcgi-wrapper) && \
+  chkconfig fastcgi-wrapper off 2>/dev/null || true
+```
+
+## 8. Fix the certbot cron
+
+The existing cron runs certbot 60 times on the 1st of each month due to a
+wildcard minute field. Fix it:
+
+```bash
+crontab -e   # or edit /etc/cron.d/certbot directly
+```
+
+Change:
+```
+* 3 1 * * root certbot-auto --nginx --force-renewal renew --post-hook="service nginx reload"
+```
+To:
+```
+0 3 1 * * root certbot-auto --nginx renew --post-hook="service nginx reload"
+```
+
+(Removed `--force-renewal` so renewal only happens when the cert is near expiry,
+and fixed the minute field from `*` to `0`.)
+
+## Rollback
+
+If anything goes wrong, restore the previous nginx config and the fastcgi-wrapper:
+
+```bash
+cp /etc/nginx/conf.d/scrollscraper.conf.pre-docker \
+   /etc/nginx/conf.d/scrollscraper.conf
+nginx -t && service nginx reload
+# restart fastcgi-wrapper if needed
+/usr/bin/perl /usr/bin/fastcgi-wrapper.pl &
+```

--- a/deploy/nginx-scrollscraper.conf
+++ b/deploy/nginx-scrollscraper.conf
@@ -1,0 +1,52 @@
+# /etc/nginx/conf.d/scrollscraper.conf
+#
+# Replaces the existing FastCGI configuration with a proxy to the
+# Docker container (docker-compose, listening on 127.0.0.1:8080).
+#
+# Changes from the previous config:
+#   - FastCGI -> proxy_pass
+#   - CGI paths rewritten: /foo.cgi -> /cgi-bin/foo.cgi (container layout)
+#   - TLS 1.0 and 1.1 removed (TLSv1.2 and TLSv1.3 only)
+#
+# Certbot renewal is unaffected: the port-80 server block below still
+# serves .well-known/acme-challenge/ via the nginx --nginx plugin as before.
+
+server {
+    if ($host = scrollscraper.adatshalom.net) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    server_name scrollscraper.adatshalom.net;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 172.31.20.152:443 ssl;
+    ssl_certificate /etc/letsencrypt/live/scrollscraper.adatshalom.net/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/scrollscraper.adatshalom.net/privkey.pem; # managed by Certbot
+    ssl_protocols TLSv1.2 TLSv1.3;
+    server_name scrollscraper.adatshalom.net;
+    access_log /srv/www/scrollscraper.adatshalom.net/logs/access.log;
+    error_log /srv/www/scrollscraper.adatshalom.net/logs/error.log;
+
+    # Rewrite top-level CGI paths to the container's cgi-bin layout.
+    # Preserves existing public URLs (e.g. /scrollscraper.cgi?...).
+    location ~ ^/([a-zA-Z0-9_-]+\.cgi)$ {
+        proxy_pass http://127.0.0.1:8080/cgi-bin/$1$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        gzip off;
+    }
+
+    # Everything else (static files, webmedia GIFs, fonts, etc.)
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,6 @@ services:
     volumes:
       - ${MP3_DIR:-./local_ort_mp3s}:/ort_mp3s
       - ${STATE_DIR:-./state}:/state
+      - ${WORK_DIR:-./scrollscraperWorkingDir}:/var/opt/scrollscraper/scrollscraperWorkingDir
     working_dir: /var/opt/scrollscraper
     command: python3 -m http.server --cgi 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  scrollscraper:
+    image: scrollscraper
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - ${MP3_DIR:-./local_ort_mp3s}:/ort_mp3s
+      - ${STATE_DIR:-./state}:/state
+    working_dir: /var/opt/scrollscraper
+    command: python3 -m http.server --cgi 80


### PR DESCRIPTION
Replaces the fastcgi-wrapper production setup with a Docker container managed by docker-compose. nginx stays on the EC2 host for TLS/LetsEncrypt; the app runs in the container on 127.0.0.1:8080.

- docker-compose.yml: one service; MP3 and state dirs configurable via .env
- .env.example: documents EC2 vs local-dev path differences
- .gitignore: excludes .env and local_ort_mp3s/ from the repo
- deploy/nginx-scrollscraper.conf: proxy_pass replaces FastCGI; rewrites top-level /foo.cgi paths to /cgi-bin/foo.cgi (container layout) so existing public URLs are preserved; drops TLS 1.0/1.1
- deploy/README.md: step-by-step cutover including certbot cron fix