### PR TITLE
Rewrite deploy README: phased rollback-safe cutover guide

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,31 +1,50 @@
 # EC2 Deployment Guide
 
-This document covers deploying ScrollScraper via docker-compose on the existing EC2,
-replacing the current fastcgi-wrapper setup. nginx remains on the host for TLS
-termination; the application runs inside a Docker container.
+Deploys ScrollScraper via docker-compose on the existing EC2, replacing the
+fastcgi-wrapper setup. nginx stays on the host for TLS/LetsEncrypt; the app
+runs in a Docker container on `127.0.0.1:8080`.
+
+**Do this in one sitting.** The nginx switch takes under a second and is
+instantly reversible, but don't leave things half-done between phases.
+
+---
 
 ## Prerequisites
 
-- Docker and docker-compose installed (docker-compose was installed at `/usr/local/bin/docker-compose`)
-- The Docker image built on the EC2 (see below)
-- The MP3 files already present on the host
+### One-time: give ec2-user Docker access
 
-## 1. Clone / update the repo on the EC2
+Running as `ec2-user`, you will get "permission denied" on the Docker socket
+unless you add yourself to the `docker` group:
 
 ```bash
-cd /newvolume/dockerWork122023/checkout/scrollscraper
-git pull
+sudo usermod -aG docker ec2-user
+newgrp docker          # activates the group in the current session without re-logging-in
 ```
 
-## 2. Build the Docker image
+### One-time: clone the repo
+
+```bash
+mkdir -p /home/ec2-user/Development/checkouts
+cd /home/ec2-user/Development/checkouts
+git clone https://github.com/jae-63/scrollscraper.git
+cd scrollscraper
+```
+
+---
+
+## Phase 1 — Build and test (zero user impact)
+
+The live site is completely untouched during this entire phase.
+
+### 1. Build the Docker image
 
 ```bash
 docker build -t scrollscraper .
 ```
 
-The first build takes 10–15 minutes. Subsequent rebuilds are faster due to layer caching.
+First build takes ~15 minutes. Subsequent rebuilds are much faster (layer cache).
 
-## 3. Create persistent directories on the host
+### 2. Create persistent host directories
 
 ```bash
 # Rate-limiting state + generated MP3 cache
@@ -36,13 +55,13 @@ touch /var/opt/scrollscraper-state/smil/daystampAndLock.txt
 mkdir -p /var/opt/scrollscraper-workdir
 ```
 
-## 4. Configure the environment
+### 3. Configure the environment
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` and set all three variables for production:
+Edit `.env` and set all three variables:
 
 ```
 MP3_DIR=/srv/www/scrollscraper.adatshalom.net/public_html/ORT_MP3s.recoded
@@ -50,55 +69,119 @@ STATE_DIR=/var/opt/scrollscraper-state
 WORK_DIR=/var/opt/scrollscraper-workdir
 ```
 
-## 5. Start the container
+### 4. Start the container
 
 ```bash
 docker-compose up -d
+docker-compose ps      # should show status "running"
 ```
 
-Verify it is running:
+### 5. Test on port 8080 — before touching nginx
 
 ```bash
-docker-compose ps
-curl -s http://127.0.0.1:8080/cgi-bin/scrollscraper.cgi \
-  "book=2&startc=15&startv=27&endc=15&endv=27" | head -5
+curl -s "http://127.0.0.1:8080/cgi-bin/scrollscraper.cgi?book=2&startc=15&startv=27&endc=15&endv=27" \
+  | grep -i "title\|error"
 ```
 
-## 6. Update the nginx config
+Expected output contains: `<title>Exodus ...`
 
-Back up the existing config, install the new one, test, and reload:
+**If this fails, stop here and debug.** The live site is still running normally
+via fastcgi-wrapper. Do not proceed to Phase 2 until this test passes.
+
+---
+
+## Phase 2 — The nginx switch (~30 seconds of risk)
+
+Only proceed once the Phase 1 test passes.
+
+### 6. Back up the current nginx config
 
 ```bash
-cp /etc/nginx/conf.d/scrollscraper.conf \
-   /etc/nginx/conf.d/scrollscraper.conf.pre-docker
-
-cp deploy/nginx-scrollscraper.conf /etc/nginx/conf.d/scrollscraper.conf
-
-nginx -t && service nginx reload
+sudo cp /etc/nginx/conf.d/scrollscraper.conf \
+        /etc/nginx/conf.d/scrollscraper.conf.pre-docker
 ```
 
-The site should now be live. Test in a browser:
-`https://scrollscraper.adatshalom.net/scrollscraper.cgi?book=2&startc=15&startv=27&endc=15&endv=27`
-
-## 7. Stop the old fastcgi-wrapper
-
-Once the Docker-based site is confirmed working:
+### 7. Install the new nginx config
 
 ```bash
-kill $(pgrep -f fastcgi-wrapper) && \
-  chkconfig fastcgi-wrapper off 2>/dev/null || true
+sudo cp deploy/nginx-scrollscraper.conf /etc/nginx/conf.d/scrollscraper.conf
 ```
 
-## 8. Fix the certbot cron
-
-The existing cron runs certbot 60 times on the 1st of each month due to a
-wildcard minute field. Fix it:
+### 8. Validate — must pass before reloading
 
 ```bash
-crontab -e   # or edit /etc/cron.d/certbot directly
+sudo nginx -t
 ```
 
-Change:
+If this does **not** say `syntax is ok`, restore and stop:
+
+```bash
+sudo cp /etc/nginx/conf.d/scrollscraper.conf.pre-docker \
+        /etc/nginx/conf.d/scrollscraper.conf
+```
+
+### 9. Reload nginx
+
+```bash
+sudo service nginx reload
+```
+
+This is graceful — in-flight requests finish before the config switches.
+
+### 10. Verify in your browser
+
+Open:
+```
+https://scrollscraper.adatshalom.net/scrollscraper.cgi?book=2&startc=15&startv=27&endc=15&endv=27
+```
+
+You should see the Torah display for Exodus 15:27.
+
+---
+
+## Rollback
+
+If anything looks wrong after the nginx reload, one command restores the previous
+setup. The fastcgi-wrapper process is never stopped during deployment, so rollback
+is immediate:
+
+```bash
+sudo cp /etc/nginx/conf.d/scrollscraper.conf.pre-docker \
+        /etc/nginx/conf.d/scrollscraper.conf \
+  && sudo nginx -t \
+  && sudo service nginx reload
+```
+
+Verify fastcgi-wrapper is still running (it should be):
+
+```bash
+pgrep -a fastcgi-wrapper
+```
+
+If it has somehow stopped:
+
+```bash
+sudo /usr/bin/perl /usr/bin/fastcgi-wrapper.pl &
+```
+
+---
+
+## Phase 3 — Cleanup (only after running happily for a day or two)
+
+Once you are confident the Docker setup is stable:
+
+### Stop fastcgi-wrapper
+
+```bash
+sudo kill $(pgrep -f fastcgi-wrapper)
+```
+
+### Fix the certbot cron
+
+The existing cron has two bugs: a wildcard minute field causes it to run 60 times
+on the 1st of each month, and `--force-renewal` forces unnecessary renewals.
+
+Edit `/etc/cron.d/certbot` — change:
 ```
 * 3 1 * * root certbot-auto --nginx --force-renewal renew --post-hook="service nginx reload"
 ```
@@ -107,17 +190,22 @@ To:
 0 3 1 * * root certbot-auto --nginx renew --post-hook="service nginx reload"
 ```
 
-(Removed `--force-renewal` so renewal only happens when the cert is near expiry,
-and fixed the minute field from `*` to `0`.)
+---
 
-## Rollback
-
-If anything goes wrong, restore the previous nginx config and the fastcgi-wrapper:
+## Keeping the repo up to date on EC2
 
 ```bash
-cp /etc/nginx/conf.d/scrollscraper.conf.pre-docker \
-   /etc/nginx/conf.d/scrollscraper.conf
-nginx -t && service nginx reload
-# restart fastcgi-wrapper if needed
-/usr/bin/perl /usr/bin/fastcgi-wrapper.pl &
+cd /home/ec2-user/Development/checkouts/scrollscraper
+git pull
+docker build -t scrollscraper .
+docker-compose up -d   # restarts the container with the new image
 ```
+
+---
+
+## Known limitation: MP3 generation
+
+The main Torah display (`scrollscraper.cgi`) works fully in Docker. The on-the-fly
+MP3 builder (`buildmp3.cgi`) has a working-directory path issue under
+`python3 -m http.server --cgi` that is tracked as a separate bug. MP3 generation
+may not work until that is fixed in a follow-on PR.


### PR DESCRIPTION
## Summary

Rewrites the EC2 deployment guide to be safer and more actionable:

- **Three explicit phases** with stop/debug gates between them — Phase 1 (build+test) has zero user impact; Phase 2 is the ~30-second nginx switch; Phase 3 is cleanup days later
- **Rollback** promoted to a prominent standalone section with a single copy-pasteable command
- **ec2-user Docker group setup** added as a prerequisite (fixes the "permission denied on docker.sock" issue)
- **Correct clone path** using HTTPS (no SSH credentials needed for public repo)
- **Known MP3 limitation** documented so it's not a surprise during cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)