### PR TITLE
Fix COPY glob destinations: add trailing slashes for older Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,12 +77,12 @@ RUN chmod 777 scrollscraper/scrollscraperWorkingDir && chmod 755 /root
 
 ADD data/webmedia.tgz /var/opt/scrollscraper/webmedia
 COPY data/entire_torah.json /var/opt/scrollscraper/data
-COPY ScrollScraperalphaPNGs/* /var/opt/scrollscraper/ScrollScraperalphaPNGs
-COPY intermediate_outputs/* /var/opt/scrollscraper/intermediate_outputs
-COPY final_outputs/* /var/opt/scrollscraper/final_outputs
-COPY fonts/* /var/opt/scrollscraper/fonts
-COPY cgi-bin/*.cgi /var/opt/scrollscraper/cgi-bin
-COPY cgi-bin/*.pm /var/opt/scrollscraper/cgi-bin
+COPY ScrollScraperalphaPNGs/* /var/opt/scrollscraper/ScrollScraperalphaPNGs/
+COPY intermediate_outputs/* /var/opt/scrollscraper/intermediate_outputs/
+COPY final_outputs/* /var/opt/scrollscraper/final_outputs/
+COPY fonts/* /var/opt/scrollscraper/fonts/
+COPY cgi-bin/*.cgi /var/opt/scrollscraper/cgi-bin/
+COPY cgi-bin/*.pm /var/opt/scrollscraper/cgi-bin/
 COPY utilities/gifETL.pl /var/opt/scrollscraper/utilities/
 COPY utilities/gifETL2.pl /var/opt/scrollscraper/utilities/
 COPY utilities/gifETL3.pl /var/opt/scrollscraper/utilities/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,12 +90,12 @@ COPY utilities/handCuration.sed /var/opt/scrollscraper/utilities/
 COPY utilities/fetchMP3s.sh /var/opt/scrollscraper/utilities/
 COPY utilities/generateSampleTorahMap.pl /var/opt/scrollscraper/utilities/
 COPY otherComputedPNGs/sampleTorahMap.png /var/opt/scrollscraper/otherComputedPNGs/
-ADD Makefile /var/opt/scrollscraper
-ADD *.html /var/opt/scrollscraper
-ADD *.txt /var/opt/scrollscraper
-ADD *.gif /var/opt/scrollscraper
-ADD *.mp3 /var/opt/scrollscraper
-ADD *.GIF /var/opt/scrollscraper
+ADD Makefile /var/opt/scrollscraper/
+ADD *.html /var/opt/scrollscraper/
+ADD *.txt /var/opt/scrollscraper/
+ADD *.gif /var/opt/scrollscraper/
+ADD *.mp3 /var/opt/scrollscraper/
+ADD *.GIF /var/opt/scrollscraper/
 
 RUN chmod 755 /var/opt/scrollscraper/cgi-bin/*.cgi
 


### PR DESCRIPTION
## Summary

Older Docker versions (present on the EC2's Amazon Linux 1) require a trailing `/` on COPY destinations when the source is a glob pattern. Podman (used on Mac) is more lenient, so the local build passed but the EC2 build failed at step 15 with:

```
When using COPY with more than one source file, the destination must be a directory and end with a /
```

Adds trailing slashes to all six affected COPY lines.

## Test plan

- [ ] `docker build -t scrollscraper .` succeeds on EC2

🤖 Generated with [Claude Code](https://claude.com/claude-code)