### PR TITLE
Alexa skill: CLI test harness, number pronunciation fix, stub missing…

### DIFF
--- a/alexa-skill/index.js
+++ b/alexa-skill/index.js
@@ -690,6 +690,24 @@ function buildResponse(options) {
   return response;
 }
 
+function numToWords(n) {
+  const ones = ['', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine',
+                'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen',
+                'seventeen', 'eighteen', 'nineteen'];
+  const tens = ['', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety'];
+  if (n < 20) return ones[n];
+  const t = Math.floor(n / 10);
+  const o = n % 10;
+  return tens[t] + (o ? '-' + ones[o] : '');
+}
+
+function handleWhenIsParshaReadIntent(request, context, session) {
+  context.succeed(buildResponse({
+    speechText: "The weekly parsha schedule is not yet available in this skill. Please check your synagogue's website for the current reading schedule.",
+    endSession: true
+  }));
+}
+
 function handleLaunchRequest(context) {
   let options = {};
   options.speechText =  "Welcome to the Scroll Scraper skill. Using our skill you can listen to and practice your scheduled Torah reading."
@@ -740,19 +758,21 @@ function handleChantIntent(request,context) {
       [numOmittedVerses,numVersesUsed,options.audioString] = chaptersAndVerses2AudioString(bookValue,startc,startv,endc,endv);
 
       if (numOmittedVerses > 0) {
-          options.speechText = "This is a truncated excerpt of " + numVersesUsed + " verses from " + bookName +  ", Chapter " + startc;
+          options.speechText = "This is a truncated excerpt of " + numVersesUsed + " verses from " + bookName +  ", Chapter " + numToWords(startc);
       } else {
-          options.speechText = "This is an excerpt from " + bookName +  ", Chapter " + startc;
+          options.speechText = "This is an excerpt from " + bookName +  ", Chapter " + numToWords(startc);
       }
       if (startc === endc) {
-          options.speechText += " verses " + startv + " through " + endv;
+          options.speechText += " verses " + numToWords(startv) + " through " + numToWords(endv);
       } else {
-          options.speechText += " verse " + startv + " through chapter " + endc + " verse " + endv;
+          options.speechText += " verse " + numToWords(startv) + " through chapter " + numToWords(endc) + " verse " + numToWords(endv);
       }
       options.speechText += ". The following recorded materials are copyright world-ORT, 1997, all rights reserved.";
       options.cardContent = scrollscraperURL;
-    
-      // test value for now
+
+      // TODO (#15): replace with the first GIF for the requested passage, looked up from gif_info.csv.
+      // The GIF filename encodes the scroll column number which can't be derived from
+      // book/chapter/verse alone without consulting the ETL output data.
       options.imageUrl = "https://scrollscraper.adatshalom.net/colorImage.cgi?thegif=/webmedia/t1/0103C111.gif&coloring=0,0,0,0,0,0";
   }
 

--- a/alexa-skill/test-locally.js
+++ b/alexa-skill/test-locally.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+'use strict';
+
+// Usage:
+//   node test-locally.js --book genesis --startc 7 --startv 3 --endv 8
+//   node test-locally.js --book numbers --startc 7 --startv 80 --endc 7 --endv 89
+//   node test-locally.js --launch
+//   node test-locally.js --parsha Bereishit
+
+const handler = require('./index');
+
+function usage() {
+  console.error(`Usage:
+  node test-locally.js --book <name> --startc <n> --startv <n> --endv <n> [--endc <n>]
+  node test-locally.js --launch
+  node test-locally.js --parsha <name>`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const get = (flag) => {
+  const i = args.indexOf(flag);
+  return i !== -1 ? args[i + 1] : undefined;
+};
+const has = (flag) => args.includes(flag);
+
+let event;
+
+if (has('--launch')) {
+  event = {
+    version: '1.0',
+    session: { new: true, sessionId: 'local-test', attributes: {}, user: { userId: 'local' }, application: { applicationId: 'local' } },
+    request: { type: 'LaunchRequest', requestId: 'local-req' }
+  };
+} else if (has('--parsha')) {
+  const parsha = get('--parsha');
+  event = {
+    version: '1.0',
+    session: { new: false, sessionId: 'local-test', attributes: {}, user: { userId: 'local' }, application: { applicationId: 'local' } },
+    request: {
+      type: 'IntentRequest',
+      requestId: 'local-req',
+      intent: {
+        name: 'WhenIsParshaReadIntent',
+        slots: { Parsha: { name: 'Parsha', value: parsha } }
+      }
+    }
+  };
+} else {
+  const book   = get('--book');
+  const startc = get('--startc');
+  const startv = get('--startv');
+  const endv   = get('--endv');
+  const endc   = get('--endc');
+
+  if (!book || !startc || !startv || !endv) usage();
+
+  event = {
+    version: '1.0',
+    session: { new: false, sessionId: 'local-test', attributes: {}, user: { userId: 'local' }, application: { applicationId: 'local' } },
+    request: {
+      type: 'IntentRequest',
+      requestId: 'local-req',
+      intent: {
+        name: 'ChantIntent',
+        slots: {
+          TorahBooks:   { name: 'TorahBooks',   value: book },
+          StartChapter: { name: 'StartChapter', value: parseInt(startc, 10) },
+          StartVerse:   { name: 'StartVerse',   value: parseInt(startv, 10) },
+          EndChapter:   { name: 'EndChapter',   value: endc ? parseInt(endc, 10) : undefined },
+          EndVerse:     { name: 'EndVerse',     value: parseInt(endv, 10) }
+        }
+      }
+    }
+  };
+}
+
+const context = {
+  succeed: (response) => {
+    const r = response.response;
+    console.log('\n--- Speech ---');
+    console.log(r.outputSpeech.ssml.replace(/<[^>]+>/g, '').trim());
+    if (r.card) {
+      console.log('\n--- Card ---');
+      console.log('Title:', r.card.title);
+      if (r.card.text)    console.log('Text:', r.card.text);
+      if (r.card.content) console.log('Content:', r.card.content);
+      if (r.card.image)   console.log('Image:', r.card.image.smallImageUrl);
+    }
+    const ssml = r.outputSpeech.ssml;
+    const audioUrls = [...ssml.matchAll(/<audio src="([^"]+)"/g)].map(m => m[1]);
+    if (audioUrls.length) {
+      console.log('\n--- Audio URLs ---');
+      audioUrls.forEach(u => console.log(u));
+    }
+    console.log('\n--- Full response JSON ---');
+    console.log(JSON.stringify(response, null, 2));
+  },
+  fail: (err) => {
+    console.error('Handler failed:', err);
+    process.exit(1);
+  }
+};
+
+process.env.NODE_DEBUG_EN = '';
+handler.handler(event, context);


### PR DESCRIPTION
… handler

- Add test-locally.js: run the Lambda handler from the command line without deploying, supporting ChantIntent, LaunchRequest, and WhenIsParshaReadIntent
- Fix spoken chapter/verse numbers via numToWords() — Alexa was saying "three-four" instead of "thirty-four" for the same gTTS bug as buildmp3.cgi
- Add handleWhenIsParshaReadIntent stub — was called but never defined, causing a runtime ReferenceError on that intent
- Clarify imageUrl TODO: the GIF column number can't be derived from book/chapter/verse without consulting gif_info.csv (tracked in #15)

Closes #15 (CLI tooling portion)