### PR TITLE
Add Route53 Terraform for scrollscraper.adatshalom.net subdomain dele…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ local_ort_mp3s/
 scrollscraperWorkingDir/
 state/
 download-mp3s
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_zone" "scrollscraper" {
+  name = "scrollscraper.adatshalom.net"
+}
+
+resource "aws_route53_record" "a" {
+  zone_id = aws_route53_zone.scrollscraper.zone_id
+  name    = "scrollscraper.adatshalom.net"
+  type    = "A"
+  ttl     = 300
+  records = [var.ec2_ip]
+}

--- a/terraform/dns/outputs.tf
+++ b/terraform/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "name_servers" {
+  description = "Give these 4 NS records to the adatshalom.net DNS manager (Google Cloud) to delegate the scrollscraper subdomain to Route53"
+  value       = aws_route53_zone.scrollscraper.name_servers
+}
+
+output "zone_id" {
+  description = "Route53 hosted zone ID (needed by future ACM and ALB Terraform)"
+  value       = aws_route53_zone.scrollscraper.zone_id
+}

--- a/terraform/dns/providers.tf
+++ b/terraform/dns/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = var.aws_profile
+}

--- a/terraform/dns/variables.tf
+++ b/terraform/dns/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_profile" {
+  description = "AWS CLI profile to use for authentication"
+  type        = string
+  default     = "default"
+}
+
+variable "ec2_ip" {
+  description = "EC2 public IP — update this when migrating to ALB/Fargate"
+  type        = string
+  default     = "54.145.225.210"
+}


### PR DESCRIPTION
…gation

Creates a hosted zone for scrollscraper.adatshalom.net and an A record pointing at the current EC2 IP (54.145.225.210).  After apply, the outputs block emits the 4 NS records to hand to the adatshalom.net manager in Google Cloud for subdomain delegation.

Once delegated, future Terraform (ACM, ALB, Fargate) can reference zone_id from this module's output.

Usage:
  cd terraform/dns
  terraform init
  terraform plan
  terraform apply        # emits name_servers output
  terraform output name_servers   # 4 NS records for Google Cloud manager


Claude-Session: https://claude.ai/code/session_01RtFNbghP7wgPrSKSem8w93